### PR TITLE
Disambiguate own boolean type as `XBoolean`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-Upcoming bug-fix release, possbily as early as 1 August 2026.
+Upcoming feature release, possbily as early as 1 August 2026.
 
 ### Fixed
 
@@ -19,11 +19,21 @@ Upcoming bug-fix release, possbily as early as 1 August 2026.
 
 ### Added
 
+ - #32: Added `XBoolean` as the xchange-specific boolean type, replacing `boolean` in prior versions. (The `boolean`
+   type is still defined for compatibility, but can be disabled by defining `_TYPEDEF_BOOLEAN` prior to including
+   `xchange.h` in your source code.).
+
  - Added `xIsDebug()` function to check on `xDebug`. While the global variable is fine in most cases, they are 
    problematic for Windows DLLs. It's better to use purely functional access instead.
    
  - `xvprintf()` / `xdprintf()` macros to reference functions instead of global vars (see above comment on Windows
    DLLs.
+   
+### Changed
+
+ - #32: Changed `boolean` parameter and return types to the equivalent `XBoolean`, to disambugiate the 
+   xchange-specific boolean type from other definitions. (Other header may define `boolean` also, and so by choosing
+   a more unique type name, we reduce the chance of namespace conflicts.)
    
 
 ## [1.2.0] - 2026-06-08

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ shows the unique __xchange__ types recognized by the library and the correspondi
 
  | `XType`       | element type             | Comment / example                                               |
  |:--------------|:------------------------:|:----------------------------------------------------------------|
- | `X_BOOLEAN`   | `boolean`                | `TRUE` (1 or non-zero) or `FALSE` (0)                           |
+ | `X_BOOLEAN`   | `XBoolean`               | `TRUE` (1 or non-zero) or `FALSE` (0)                           |
  | `X_BYTE`      | `char`                   | '`-128`' to  '`127`'                                            |
  | `X_INT16`     | `int16_t`                | '`-32768`' to '`32767`'                                         |
  | `X_INT32`     | `int32_t`                | '`-2,147,483,648`' to '`2,147,483,647`'                         |
@@ -340,9 +340,9 @@ shows the unique __xchange__ types recognized by the library and the correspondi
  | `X_FIELD`     | `XField`                 | For irregular and/or heterogeneous arrays                       |
  | `X_STRUCT`    | `XStructure`             | substructure                                                    |
 
-The `boolean` type is defined in `xchange.h`. The `XField.value` is a pointer / array of the given element type. So,
-an `XField` of type `X_DOUBLE` will have a `value` field that should be cast a `(double *)`, while for type `X_STRING`
-the value field shall be cast as `(char **)`.
+The `XField.value` is a pointer / array of the given element type. So, an `XField` of type `X_DOUBLE` will have a 
+`value` field that should be cast a `(double *)`, while for type `X_STRING` the value field shall be cast as 
+`(char **)`.
 
 Additionally, the __xchange__ also defines derivative `XType` values for native integer storage types, whose widths 
 depend on the particular CPU architecture. Hence, these are aliased to matching unique types (above) by the C 
@@ -354,6 +354,18 @@ preprocessor during compilation:
  | `X_INT`       | `int`                    |   &gt;= 16-bits  | often `X_INT32`                            |
  | `X_LONG`      | `long`                   |   &gt;= 32-bits  | typically `X_INT32` or `X_INT64`           |
  | `X_LLONG`     | `long long`              |   &gt;= 64-bits  | typically `X_INT64`                        |
+
+
+By default, a `boolean` type (same as `XBoolean`) is also defined in `xchange.h` to maintain compatibility with 
+releases prior to __v1.3__. If you prefer to use a different `boolean` type, such as defined by another header, 
+simply define `_TYPEDEF_BOOLEAN` prior to including `xchange.h` in your source code to indicate that `xchange.h` 
+should avoid (re)defining `boolean`. E.g.:
+
+```c
+ #define _TYPEDEF_BOOLEAN   // indicates that we have a custom definition for a `boolean` type
+ #include <xchange.h>       // xchange.h, without defining its own `boolean` type.
+```
+
 
 
 <a name="xchange-strings"></a>

--- a/examples/example-json.c
+++ b/examples/example-json.c
@@ -64,7 +64,7 @@ static XStructure *create_my_struct() {
 
   int i1[] = {1, 2};                    // 1D array of integers
   char *s2[] = {"aa", "bb", "cc"};      // 1D array of strings
-  boolean b3[] = {TRUE};                // boolean array
+  XBoolean b3[] = {TRUE};                // boolean array
 
   // -------------------------------------------------------------------------
   // Heterogeneous array...

--- a/include/xchange.h
+++ b/include/xchange.h
@@ -20,7 +20,7 @@
 #define XCHANGE_MAJOR_VERSION  1
 
 /// API minor version
-#define XCHANGE_MINOR_VERSION  2
+#define XCHANGE_MINOR_VERSION  3
 
 /// Integer sub version of the release
 #define XCHANGE_PATCHLEVEL     0
@@ -153,11 +153,26 @@ typedef int XType;          ///< SMA-X data type.
 #define X_MAX_STRING_DIMS               (2 * X_MAX_DIMS + 1)    ///< \hideinitializer Maximum length of string representation of dimensions
 #define X_MAX_ELEMENTS                  (1<<X_MAX_DIMS)         ///< \hideinitializer Maximum number of array elements (~1 million).
 
-#if defined(_MSC_VER)
-#  include <windows.h>             // for boolean
-#elif !defined(_TYPEDEF_BOOLEAN)
+/**
+ * The xchange default boolean TRUE/FALSE data type. It is also aliased as `boolean`, unless the `_TYPEDEF_BOOLEAN` is
+ * already set when `xchange.h` is included, to maintain compatibility with previous xchange releases, which only defined
+ * `boolean`. If you don't want xchange to define a `boolean` type, e.g. because you use another header that defines
+ * it differently, then simply define `_TYPEDEF_BOOLEAN` before including `xchange.h` in your source code, e.g. as:
+ *
+ * ```c
+ * #define _TYPEDEF_BOOLEAN   // indicates that we have a custom definition for a boolean type
+ * #include <xchange.h>       // xchange.h, without defining its own `boolean` type.
+ * ```
+ *
+ * @since 1.3
+ */
+typedef int XBoolean;
+
+// If not Windows/MSC (which defines a `boolean` type in `windows.h`), and _TYPEDEF_BOOLEAN wasn't explicitl defined to
+// indicate a custom definition for `boolean`, then define `boolean` to be the same a `XBoolean`.
+#if !defined(_MSC_VER) && !defined(_TYPEDEF_BOOLEAN)
 #  define _TYPEDEF_BOOLEAN         ///< Precompiler constant to indicate that we use the xchange definition of a boolean
-typedef int boolean;               ///< the xchange default boolean TRUE/FALSE data type.
+typedef XBoolean boolean;          ///< compatibility boolean TRUE/FALSE data type prior to v1.3. Same as XBoolean.
 #endif
 
 #ifndef NAN
@@ -175,11 +190,11 @@ typedef int boolean;               ///< the xchange default boolean TRUE/FALSE d
 /**
  * \brief An SMA-X field, typically as part of an XStructure. A field may be a reference to a nested XStructure itself.
  *
- * \sa smaxCreateField()
- * \sa smaxCreateScalarField()
- * \sa smaxCreate1DField()
- * \sa smaxDestroyField()
- * \sa smaxShareField()
+ * \sa xCreateField()
+ * \sa xCreateScalarField()
+ * \sa xCreate1DField()
+ * \sa xDestroyField()
+ * \sa xShareField()
  */
 typedef struct XField {
   char *name;               ///< Pointer to a designated local name buffer. It may not contain a separator (see X_SEP).
@@ -192,7 +207,7 @@ typedef struct XField {
                             ///< NOTE: it should normally be dynamically allocated, to work with xClearField() / xDestroyField().
   int ndim;                 ///< The dimensionality of the data
   int sizes[X_MAX_DIMS];    ///< The sizes along each dimension
-  boolean isSerialized;     ///< Whether the fields is stored in serialized (string) format.
+  XBoolean isSerialized;     ///< Whether the fields is stored in serialized (string) format.
   struct XField *next;      ///< Pointer to the next linked element (if inside an XStructure).
 } XField;
 
@@ -204,9 +219,9 @@ typedef struct XField {
 /**
  * \brief SMA-X structure object, containing a linked-list of XField elements.
  *
- * \sa smaxCreateStruct()
- * \sa smaxDestroyStruct()
- * \sa smaxShareStruct()
+ * \sa xCreateStruct()
+ * \sa xDestroyStruct()
+ * \sa xShareStruct()
  */
 typedef struct XStructure {
   XField *firstField;           ///< Pointer to the first field in this structure or NULL if the structure is empty.
@@ -231,17 +246,17 @@ typedef struct {
  */
 #define X_STRUCT_INIT       {NULL}
 
-extern boolean xVerbose;        ///< Switch to enable verbose console output for XChange operations.
-extern boolean xDebug;          ///< Switch to enable debugging (very verbose) output for XChange operations.
+extern XBoolean xVerbose;        ///< Switch to enable verbose console output for XChange operations.
+extern XBoolean xDebug;          ///< Switch to enable debugging (very verbose) output for XChange operations.
 
 #define xvprintf if(xIsVerbose()) printf        ///< Use for generating verbose output
 #define xdprintf if(xIsDebug()) printf          ///< Use for generating debug output
 
 // In xutil.c ------------------------------------------------>
-boolean xIsVerbose();
-void xSetVerbose(boolean value);
-boolean xIsDebug();
-void xSetDebug(boolean value);
+XBoolean xIsVerbose();
+void xSetVerbose(XBoolean value);
+XBoolean xIsDebug();
+void xSetDebug(XBoolean value);
 int xError(const char *fn, int code);
 const char *xErrorDescription(int code);
 
@@ -258,7 +273,7 @@ void xDestroyField(XField *f);
 XField *xGetField(const XStructure *s, const char *name);
 XField *xSetField(XStructure *s, XField *f);
 XField *xRemoveField(XStructure *s, const char *name);
-boolean xIsFieldValid(const XField *f);
+XBoolean xIsFieldValid(const XField *f);
 long xGetFieldCount(const XField *f);
 void *xGetElementAtIndex(const XField *f, int idx);
 long xGetAsLongAtIndex(const XField *f, int idx, long defaultValue);
@@ -277,18 +292,18 @@ int xReduceStruct(XStructure *s);
 int xReduceField(XField *f);
 
 // Sorting, ordering
-int xSortFields(XStructure *s, int (*cmp)(const XField **f1, const XField **f2), boolean recursive);
-int xSortFieldsByName(XStructure *s, boolean recursive);
-int xReverseFieldOrder(XStructure *s, boolean recursive);
+int xSortFields(XStructure *s, int (*cmp)(const XField **f1, const XField **f2), XBoolean recursive);
+int xSortFieldsByName(XStructure *s, XBoolean recursive);
+int xReverseFieldOrder(XStructure *s, XBoolean recursive);
 
 // Field lookup
 XLookupTable *xAllocLookup(unsigned int size);
-XLookupTable *xCreateLookup(const XStructure *s, boolean recursive);
+XLookupTable *xCreateLookup(const XStructure *s, XBoolean recursive);
 XField *xLookupField(const XLookupTable *tab, const char *id);
 int xLookupPut(XLookupTable *tab, const char *prefix, const XField *field, XField **oldValue);
 XField *xLookupRemove(XLookupTable *tab, const char *id);
-int xLookupPutAll(XLookupTable *tab, const char *prefix, const XStructure *s, boolean recursive);
-int xLookupRemoveAll(XLookupTable *tab, const char *prefix, const XStructure *s, boolean recursive);
+int xLookupPutAll(XLookupTable *tab, const char *prefix, const XStructure *s, XBoolean recursive);
+int xLookupRemoveAll(XLookupTable *tab, const char *prefix, const XStructure *s, XBoolean recursive);
 long xLookupCount(const XLookupTable *tab);
 void xDestroyLookup(XLookupTable *tab);
 void xDestroyLookupAndData(XLookupTable *tab);
@@ -297,7 +312,7 @@ void xDestroyLookupAndData(XLookupTable *tab);
 XField *xCreateDoubleField(const char *name, double value);
 XField *xCreateIntField(const char *name, int value);
 XField *xCreateLongField(const char *name, long long value);
-XField *xCreateBooleanField(const char *name, boolean value);
+XField *xCreateBooleanField(const char *name, XBoolean value);
 XField *xCreateStringField(const char *name, const char *value);
 XField *xCreate1DField(const char *name, XType type, int count, const void *values);
 XField *xCreateMixedArrayField(const char *name, int ndim, const int *sizes, XField *value);
@@ -305,7 +320,7 @@ XField *xCreateMixed1DField(const char *name, int size, XField *value);
 int xSetSubtype(XField *f, const char *type);
 
 // Parsers / formatters
-boolean xParseBoolean(const char *str, char **end);
+XBoolean xParseBoolean(const char *str, char **end);
 float xParseFloat(const char *str, char **tail);
 double xParseDouble(const char *str, char **tail);
 int xPrintDouble(char *str, double value);
@@ -318,10 +333,10 @@ int xPrintDimsN(char *dst, int ndim, const int *sizes, size_t len);
 
 // Low-level utilities ---------------------------------------->
 char xTypeChar(XType type);
-boolean xIsCharSequence(XType type);
-boolean xIsInteger(XType type);
-boolean xIsDecimal(XType type);
-boolean xIsNumeric(XType type);
+XBoolean xIsCharSequence(XType type);
+XBoolean xIsInteger(XType type);
+XBoolean xIsDecimal(XType type);
+XBoolean xIsNumeric(XType type);
 char *xLastSeparator(const char *id);
 char *xNextIDToken(const char *id);
 char *xCopyIDToken(const char *id);

--- a/src/xchange.c
+++ b/src/xchange.c
@@ -30,12 +30,12 @@
 #define __XCHANGE_INTERNAL_API__      ///< Use internal definitions
 #include "xchange.h"
 
-boolean xVerbose;
+XBoolean xVerbose;
 
 #ifdef DEBUG
-boolean xDebug = TRUE;
+XBoolean xDebug = TRUE;
 #else
-boolean xDebug = FALSE;
+XBoolean xDebug = FALSE;
 #endif
 
 /**
@@ -130,7 +130,7 @@ int x_warn(const char *from, const char *desc, ...) {
  *
  * @sa xSetVerbose()
  */
-boolean xIsVerbose() {
+XBoolean xIsVerbose() {
   return xVerbose;
 }
 
@@ -141,7 +141,7 @@ boolean xIsVerbose() {
  *
  * @sa xIsVerbose(), xSetDebug()
  */
-void xSetVerbose(boolean value) {
+void xSetVerbose(XBoolean value) {
   xVerbose = value ? TRUE : FALSE;
 }
 
@@ -150,11 +150,11 @@ void xSetVerbose(boolean value) {
  *
  * @return      TRUE (1) if debug output is enabled, otherwise FALSE (0).
  *
- * @since 1.2.1
+ * @since 1.3
  *
  * @sa xSetDebug()
  */
-boolean xIsDebug() {
+XBoolean xIsDebug() {
   return xDebug;
 }
 
@@ -165,7 +165,7 @@ boolean xIsDebug() {
  *
  * @sa xIsDebug(), xSetVerbose()
  */
-void xSetDebug(boolean value) {
+void xSetDebug(XBoolean value) {
   xDebug = value ? TRUE : FALSE;
 }
 
@@ -177,7 +177,7 @@ void xSetDebug(boolean value) {
  * \return          TRUE (1) if it is a type for a (fixed size) character array, otherwise FALSE (0).
  *
  */
-boolean xIsCharSequence(XType type) {
+XBoolean xIsCharSequence(XType type) {
   return type < 0;
 }
 
@@ -191,7 +191,7 @@ boolean xIsCharSequence(XType type) {
  * @sa xIsNumeric()
  * @sa xGetAsLong()
  */
-boolean xIsInteger(XType type) {
+XBoolean xIsInteger(XType type) {
   switch(type) {
     case X_BOOLEAN:
     case X_BYTE:
@@ -214,7 +214,7 @@ boolean xIsInteger(XType type) {
  * @sa xIsNumeric()
  * @sa xGetAsDouble()
  */
-boolean xIsDecimal(XType type) {
+XBoolean xIsDecimal(XType type) {
   return (type == X_FLOAT || type == X_DOUBLE);
 }
 
@@ -227,7 +227,7 @@ boolean xIsDecimal(XType type) {
  * @sa xIsInteger()
  * @sa xIsDecimal()
  */
-boolean xIsNumeric(XType type) {
+XBoolean xIsNumeric(XType type) {
   return (xIsInteger(type) || xIsDecimal(type));
 }
 
@@ -280,7 +280,7 @@ int xElementSizeOf(XType type) {
   if(type < 0) return -type;
   switch(type) {
     case X_RAW: return sizeof(char *);
-    case X_BOOLEAN: return sizeof(boolean);
+    case X_BOOLEAN: return sizeof(XBoolean);
     case X_BYTE: return sizeof(char);
     case X_INT16: return sizeof(int16_t);
     case X_INT32: return sizeof(int32_t);
@@ -429,10 +429,10 @@ int xParseDims(const char *src, int *sizes) {
 }
 
 /**
- * Allocates a buffer for a given SMA-X type and element count. The buffer is initialized
+ * Allocates a buffer for a given xchange type and element count. The buffer is initialized
  * with zeroes.
  *
- * \param type      SMA-X type
+ * \param type      xchange data type
  * \param count     number of elements.
  *
  * \return      Pointer to the initialized buffer or NULL if there was an error (errno will
@@ -459,10 +459,10 @@ void *xAlloc(XType type, int count) {
 }
 
 /**
- * Zeroes out the contents of an SMA-X buffer.
+ * Zeroes out the contents of an xchange typed data buffer.
  *
  * \param buf       Pointer to the buffer to fill with zeroes.
- * \param type      SMA-X type
+ * \param type      xchange data type
  * \param count     number of elements.
  */
 void xZero(void *buf, XType type, int count) {
@@ -515,7 +515,7 @@ static int TokenMatch(const char *a, const char *b) {
  * @param end   Where the pointer to after the successfully parsed token is returned, on NULL.
  * @return      TRUE (1) or FALSE (0).
  */
-boolean xParseBoolean(const char *str, char **end) {
+XBoolean xParseBoolean(const char *str, char **end) {
   static const char *fn = "xParseBoolean";
 
   static char *trues[] = { "true", "t", "on", "yes", "y", "enabled", "active", NULL };

--- a/src/xjson.c
+++ b/src/xjson.c
@@ -56,7 +56,7 @@ static char *ParseString(char **pos, int *lineNumber);
 static void *ParsePrimitive(char **pos, XType *type, int *lineNumber);
 
 static long GetObjectStringSize(int prefixSize, const XStructure *s);
-static long GetFieldStringSize(int prefixSize, const XField *f, boolean ignoreName);
+static long GetFieldStringSize(int prefixSize, const XField *f, XBoolean ignoreName);
 static long GetArrayStringSize(int prefixSize, char *ptr, XType type, int ndim, const int *sizes);
 static long GetJsonStringSize(const char *src, int maxLength);
 
@@ -759,7 +759,7 @@ static void *ParsePrimitive(char **pos, XType *type, int *lineNumber) {
 
   // Check if boolean
   if(l == JSON_TRUE_LEN) if(!strncmp(next, JSON_TRUE, JSON_TRUE_LEN)) {
-    boolean *value = malloc(sizeof(boolean));
+    XBoolean *value = malloc(sizeof(XBoolean));
     x_check_alloc(value);
     *value = TRUE;
     *type = X_BOOLEAN;
@@ -767,7 +767,7 @@ static void *ParsePrimitive(char **pos, XType *type, int *lineNumber) {
   }
 
   if(l == JSON_FALSE_LEN) if(!strncmp(next, JSON_FALSE, JSON_FALSE_LEN)) {
-    boolean *value = malloc(sizeof(boolean));
+    XBoolean *value = malloc(sizeof(XBoolean));
     x_check_alloc(value);
     *value = FALSE;
     *type = X_BOOLEAN;
@@ -890,7 +890,7 @@ static void *ParseArray(char **pos, XType *type, int *ndim, int sizes[X_MAX_DIMS
 
   for(n = 0; *next && *next != ']';) {
     XField *e;
-    boolean isValid;
+    XBoolean isValid;
 
     e = (XField *) calloc(1, sizeof(XField));
     x_check_alloc(e);
@@ -1099,7 +1099,7 @@ static long PrintObject(const char *prefix, const XStructure *s, char *str, size
   return n;
 }
 
-static long GetFieldStringSize(int prefixSize, const XField *f, boolean ignoreName) {
+static long GetFieldStringSize(int prefixSize, const XField *f, XBoolean ignoreName) {
   static const char *fn = "GetFieldStringSize";
 
   long n = prefixSize + 2, m;      // <value> + `,\n`
@@ -1195,7 +1195,7 @@ static long GetArrayStringSize(int prefixSize, char *ptr, XType type, int ndim, 
   else {
     const int N = sizes[0];
     const int rowSize = SizeOf(type, ndim-1, &sizes[1]);
-    const boolean newLine = IsNewLine(type, ndim);
+    const XBoolean newLine = IsNewLine(type, ndim);
     int k;
 
     long n = 4;     // "[ " + .... +  " ]" or "[\n" + ... + "\n]"
@@ -1243,7 +1243,7 @@ static long PrintArray(const char *prefix, char *ptr, XType type, int ndim, cons
   else {
     const int N = sizes[0];
     const int rowSize = ptr ? SizeOf(type, ndim-1, &sizes[1]) : 0;
-    const boolean newLine = ptr ? IsNewLine(type, ndim) : FALSE;
+    const XBoolean newLine = ptr ? IsNewLine(type, ndim) : FALSE;
     size_t n = 0, plen;
 
     int k;
@@ -1319,7 +1319,7 @@ static long PrintPrimitive(const void *ptr, XType type, char *str, size_t len) {
 
   switch(type) {
     case X_UNKNOWN: return x_snprintf(str, len, JSON_NULL);
-    case X_BOOLEAN: return x_snprintf(str, len, (*(boolean *)ptr ? JSON_TRUE : JSON_FALSE));
+    case X_BOOLEAN: return x_snprintf(str, len, (*(XBoolean *)ptr ? JSON_TRUE : JSON_FALSE));
     case X_BYTE: return x_snprintf(str, len, "%hhu", *(unsigned char *) ptr);
     case X_FLOAT: return xPrintFloatN(str, *(float *) ptr, len);
     case X_DOUBLE: return xPrintDoubleN(str, *(double *) ptr, len);

--- a/src/xlookup.c
+++ b/src/xlookup.c
@@ -205,7 +205,7 @@ XField *xLookupRemove(XLookupTable *tab, const char *id) {
 
 
 
-static int xLookupPutAllAsync(XLookupTable *tab, const char *prefix, const XStructure *s, boolean recursive) {
+static int xLookupPutAllAsync(XLookupTable *tab, const char *prefix, const XStructure *s, XBoolean recursive) {
   XField *f;
   int lp = prefix ? strlen(prefix) : 0;
   int N = 0;
@@ -242,7 +242,7 @@ static int xLookupPutAllAsync(XLookupTable *tab, const char *prefix, const XStru
   return N;
 }
 
-static int xLookupRemoveAllAsync(XLookupTable *tab, const char *prefix, const XStructure *s, boolean recursive) {
+static int xLookupRemoveAllAsync(XLookupTable *tab, const char *prefix, const XStructure *s, XBoolean recursive) {
   XField *f;
   int lp = prefix ? strlen(prefix) : 0;
   int N = 0;
@@ -296,7 +296,7 @@ static int xLookupRemoveAllAsync(XLookupTable *tab, const char *prefix, const XS
  *
  * @sa xLookupRemoveAll()
  */
-int xLookupPutAll(XLookupTable *tab, const char *prefix, const XStructure *s, boolean recursive) {
+int xLookupPutAll(XLookupTable *tab, const char *prefix, const XStructure *s, XBoolean recursive) {
   static const char *fn = "xLookupPutAll";
 
   // cppcheck-suppress constVariablePointer
@@ -331,7 +331,7 @@ int xLookupPutAll(XLookupTable *tab, const char *prefix, const XStructure *s, bo
  *
  * @sa xLookupRemoveAll()
  */
-int xLookupRemoveAll(XLookupTable *tab, const char *prefix, const XStructure *s, boolean recursive) {
+int xLookupRemoveAll(XLookupTable *tab, const char *prefix, const XStructure *s, XBoolean recursive) {
   static const char *fn = "xLookupRemoveAll";
 
   // cppcheck-suppress constVariablePointer
@@ -418,7 +418,7 @@ XLookupTable *xAllocLookup(unsigned int size) {
  * @sa xLookupField()
  * @sa xDestroyLookup()
  */
-XLookupTable *xCreateLookup(const XStructure *s, boolean recursive) {
+XLookupTable *xCreateLookup(const XStructure *s, XBoolean recursive) {
   static const char *fn = "xCreateLookup";
 
   XLookupTable *l;
@@ -493,7 +493,7 @@ XField *xLookupField(const XLookupTable *tab, const char *id) {
  * @sa xDestroyLookupAndData()
  * @sa xCreateLookup()
  */
-static void xDestroyLookupOption(XLookupTable *tab, boolean destroyFields) {
+static void xDestroyLookupOption(XLookupTable *tab, XBoolean destroyFields) {
   // cppcheck-suppress constVariablePointer
   XLookupPrivate *p;
 

--- a/src/xstruct.c
+++ b/src/xstruct.c
@@ -21,7 +21,7 @@
 /**
  * Creates a new empty XStructure.
  *
- * \sa smaxDestroyStruct()
+ * \sa xDestroyStruct()
  *
  */
 XStructure *xCreateStruct() {
@@ -396,7 +396,7 @@ long xGetAsLongAtIndex(const XField *f, int idx, long defaultValue) {
   }
 
   switch(f->type) {
-    case X_BOOLEAN: return *(boolean *) ptr;
+    case X_BOOLEAN: return *(XBoolean *) ptr;
     case X_BYTE: return *(int8_t *) ptr;
     case X_INT16: return *(int16_t *) ptr;
     case X_INT32: return *(int32_t *) ptr;
@@ -509,7 +509,7 @@ double xGetAsDoubleAtIndex(const XField *f, int idx) {
   }
 
   switch(f->type) {
-    case X_BOOLEAN: return *(boolean *) ptr;
+    case X_BOOLEAN: return *(XBoolean *) ptr;
     case X_BYTE: return *(int8_t *) ptr;
     case X_INT16: return *(int16_t *) ptr;
     case X_INT32: return *(int32_t *) ptr;
@@ -832,7 +832,7 @@ XField *xCreateLongField(const char *name, long long value) {
  *
  * \return          A newly created field with the supplied data, or NULL if there was an error.
  */
-XField *xCreateBooleanField(const char *name, boolean value) {
+XField *xCreateBooleanField(const char *name, XBoolean value) {
   XField *f = xCreateScalarField(name, X_BOOLEAN, &value);
   if(!f) return x_trace_null("xCreateBooleanField", NULL);
   return f;
@@ -880,7 +880,7 @@ int xSetSubtype(XField *f, const char *type) {
  * \return          TRUE is the field seems to contain valid data, otherwise FALSE.
  *
  */
-boolean xIsFieldValid(const XField *f) {
+XBoolean xIsFieldValid(const XField *f) {
   int i;
   if(f->name == NULL) return FALSE;
   if(xLastSeparator(f->name)) return FALSE;
@@ -1256,7 +1256,7 @@ void xDestroyField(XField *f) {
  *
  * @param s    Pointer to the structure to be cleared.
  *
- * @sa smaDestroyStruct()
+ * @sa xDestroyStruct()
  */
 void xClearStruct(XStructure *s) {
   XField *f;
@@ -1496,7 +1496,7 @@ int xMatchNextID(const char *token, const char *id) {
  * Returns the aggregated (hierarchical) &lt;table&gt;:&lt;key&gt; ID. The caller is responsible for calling free()
  * on the returned string after use.
  *
- * \param table     SMA-X hastable name
+ * \param table     xchange top-level group / hashtable name
  * \param key       The lower-level id to concatenate.
  *
  * \return          The aggregated ID, or NULL if both arguments were NULL themselves.
@@ -1531,7 +1531,7 @@ char *xGetAggregateID(const char *table, const char *key) {
 /**
  * Returns the string pointer to the begining of the last separator in the ID.
  *
- * @param id    Compound SMA-X ID.
+ * @param id    Compound xchange ID.
  * @return      Pointer to the beginning of the last separator in the ID, or NULL if the ID does not contain a separator.
  *
  * @sa xSplitID()
@@ -1633,7 +1633,7 @@ long xDeepCountFields(const XStructure *s) {
  * @sa xSortFieldsByName()
  * @sa xReverseFieldOrder()
  */
-int xSortFields(XStructure *s, int (*cmp)(const XField **f1, const XField **f2), boolean recursive) {
+int xSortFields(XStructure *s, int (*cmp)(const XField **f1, const XField **f2), XBoolean recursive) {
   static const char *fn = "xSortFields";
 
   XField **array, *f;
@@ -1684,7 +1684,7 @@ static int XFieldNameCmp(const XField **f1, const XField **f2) {
  *
  * @sa xReverseFieldOrder()
  */
-int xSortFieldsByName(XStructure *s, boolean recursive) {
+int xSortFieldsByName(XStructure *s, XBoolean recursive) {
   prop_error("xSortFieldsByName", xSortFields(s, XFieldNameCmp, recursive));
   return X_SUCCESS;
 }
@@ -1700,7 +1700,7 @@ int xSortFieldsByName(XStructure *s, boolean recursive) {
  * @sa xSortFieldsByName()
  * @sa xInsertField()
  */
-int xReverseFieldOrder(XStructure *s, boolean recursive) {
+int xReverseFieldOrder(XStructure *s, XBoolean recursive) {
   XField *f, *rev = NULL;
 
   if(s == NULL) return x_error(X_NULL, EINVAL, "xReverseFieldOrder", "input structure is NULL");

--- a/test/test-json.c
+++ b/test/test-json.c
@@ -24,7 +24,7 @@ static XStructure *createStruct() {
 
   int i1[] = {1, 2};
   char *s2[] = {"aa", "bb", "cc"};
-  boolean b3[] = {TRUE};
+  XBoolean b3[] = {TRUE};
 
   // Heterogeneous array...
   XField *f1 = xCreate1DField(".1", X_INT, 2, i1);


### PR DESCRIPTION
- New `XBoolean` type to define an xchange-specific boolean type
- `boolean` remains defined also for back compatibility with prior versions, unless the user defines the `_TYPEDEF_BOOLEAN` macro prior to including `xchange.h` to indicate that a `boolean` type is defined elsewhere, and it should not be used in the context of the `xchange` library.  