### PR TITLE
`x_snprintf()` to return actual number of bytes printed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Upcoming feature release, possibly as early as 1 August 2026.
 
 ### Fixed
 
+ - #33: `x_snprintf()` to return the actual number of bytes printed, since this is how the library and its 
+   dependencies have used this function.
+
  - CMake `xchangeConfig` to skip requiring math lib for non-Windows platforms in general, since it can fail if the 
    math library is in the build path, but not in the search path, such as for some cross builds (see e.g. the vcpkg 
    Android builds)

--- a/include/xchange.h
+++ b/include/xchange.h
@@ -374,16 +374,14 @@ int x_warn(const char *from, const char *desc, ...);
 int x_trace(const char *loc, const char *op, int n);
 void *x_trace_null(const char *loc, const char *op);
 
+int x_snprintf(char *buf, size_t len, const char *fmt, ...);
+
 // Check to see if snprintf() is available, or if we should use our own dummy version of it.
-#if !defined(X_NO_SNPRINTF) && ( defined(snprintf) || defined(__cplusplus) || __STDC_VERSION__ >= 199901L \
+#if defined(X_NO_SNPRINTF) || !( defined(snprintf) || defined(__cplusplus) || __STDC_VERSION__ >= 199901L \
         || defined(_MSC_VER) || defined(_ISOC99_SOURCE) || _XOPEN_SOURCE >= 500 || defined(_BSD_SOURCE) )
-#  define x_snprintf    snprintf      ///< Use the builtin snprintf() function
-#else
 #  ifndef X_NO_SNPRINTF
 #    define X_NO_SNPRINTF             ///< Use out own dummy version of snprintf() (which is the same as sprintf())
 #  endif
-
-int x_snprintf(char *buf, size_t len, const char *fmt, ...);
 #endif
 
 /**

--- a/src/xchange.c
+++ b/src/xchange.c
@@ -876,6 +876,36 @@ int x_snprintf(char *buf, size_t len, const char *fmt, ...) {
   va_start(varg, fmt);
   n = vsprintf(buf, fmt, varg);
   va_end(varg);
+
+  if(n >= (int) len) {
+    fprintf(stderr, "ERROR! Memory corruption. Abort execution\n");
+    fprintf(stderr, "       x_snprintf() printed %d bytes into space of %zu bytes (fmt '%s').", n, len, fmt);
+    exit(EFAULT);
+  }
+
   return n;
 }
+#else
+
+/**
+ * Similar to `snprintf()`, expect the return value can never exceed len - 1.
+ *
+ * @param buf     buffer into which to print
+ * @param len     the size of the buffer
+ * @param fmt     the format string
+ *
+ * @return        The number of characters actually printed, excluding termination.
+ *                Unlike the standard C snprintf() It shall never exceed len - 1.
+ */
+int x_snprintf(char *buf, size_t len, const char *fmt, ...) {
+  va_list va;
+  int n;
+
+  va_start(va, fmt);
+  n = vsnprintf(buf, len, fmt, va);
+  va_end(va);
+
+  return n < (int) len ? n : (int) len - 1;
+}
+
 #endif // X_NO_SNPRINTF


### PR DESCRIPTION
The standard `snprintf()` function returns the number of bytes that *would have been* printed, not the number of bytes actually printed. The library and its dependents (__redisx__, __smax-clib__, __smax-postgres__) have thus used it incorrectly. The easiest fix is to change the specification for return value of `x_snprintf()` to deviate from the standard `snprintf()`, s.t.:

 - `x_snprintf()` returns the actual number of bytes printed (excluding termination), which can never exceed `len - 1`.
 - On platforms that use `sprintf()` for the implementation, because they do not define `vsnprintf()`, the library will force exit, when the overflow results in memory corruption. (It is better to notify the developer so they can fix it, e.g. by increasing the size of the buffer used).